### PR TITLE
Add student profile 

### DIFF
--- a/src/components/TeamProfileCards/index.tsx
+++ b/src/components/TeamProfileCards/index.tsx
@@ -260,6 +260,16 @@ export function StudentFellowsTeamRow(): ReactNode {
           }
         </Translate>
       </TeamProfileCardCol>
+      <TeamProfileCardCol
+        name="Hamid ELaaly"
+        githubUrl="https://github.com/hamidElaaly"
+        >
+        <Translate id="team.profile.Hamid Elaaly.body">
+          {
+            ''
+          }
+        </Translate>
+      </TeamProfileCardCol>
     </div>
   );
 }


### PR DESCRIPTION
Adding a missing profile in the student fellows section. This update completes the team page by providing information about the team members' backgrounds for the project.